### PR TITLE
The same PR I made last time

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -457,8 +457,8 @@ def process_images(outpath, func_init, func_sample, prompt, seed, sampler_name, 
             seeds = all_seeds[n * batch_size:(n + 1) * batch_size]
 
             uc = None
-            if cfg_scale != 1.0:
-                uc = model.get_learned_conditioning(len(prompts) * [""])
+            # if cfg_scale != 1.0:
+            uc = model.get_learned_conditioning(len(prompts) * [""])
             if isinstance(prompts, tuple):
                 prompts = list(prompts)
 

--- a/webui.py
+++ b/webui.py
@@ -456,8 +456,6 @@ def process_images(outpath, func_init, func_sample, prompt, seed, sampler_name, 
             prompts = all_prompts[n * batch_size:(n + 1) * batch_size]
             seeds = all_seeds[n * batch_size:(n + 1) * batch_size]
 
-            uc = None
-            # if cfg_scale != 1.0:
             uc = model.get_learned_conditioning(len(prompts) * [""])
             if isinstance(prompts, tuple):
                 prompts = list(prompts)

--- a/webui.py
+++ b/webui.py
@@ -558,9 +558,8 @@ def txt2img(prompt: str, ddim_steps: int, sampler_name: str, toggles: list, ddim
     err = False
     seed = seed_to_int(seed)
 
-    # print('toggles:', toggles)
     prompt_matrix = 0 in toggles
-    normalize_prompt_weights = toggles[1]
+    normalize_prompt_weights = 1 in toggles
     skip_save = 2 not in toggles
     skip_grid = 3 not in toggles
     use_GFPGAN = 4 in toggles
@@ -718,7 +717,7 @@ def img2img(prompt: str, init_info, mask_mode, ddim_steps: int, sampler_name: st
     seed = seed_to_int(seed)
 
     prompt_matrix = 0 in toggles
-    normalize_prompt_weights = toggles[1]
+    normalize_prompt_weights = 1 in toggles
     loopback = 2 in toggles
     skip_save = 3 not in toggles
     skip_grid = 4 not in toggles


### PR DESCRIPTION
`1 in toggles` is right. I'm not an idiot who doesn't know how to read an array index.

For example, the img2img options look like this right now:
```
img2img_toggles = [
    'Create prompt matrix (separate multiple prompts using |, and get all combinations of them)',
    'Normalize Prompt Weights (ensure sum of weights add up to 1.0)',
    'Loopback (use images from previous batch when creating next batch)',
    'Save individual images',
    'Save grid',
]
```
And if for example we were to tick these in the UI, in this order:
```
'Create prompt matrix (separate multiple prompts using |, and get all combinations of them)',
'Save individual images',
'Loopback (use images from previous batch when creating next batch)',
```
the list sent to img2img's `toggles` var would look like `[0,3,2]`

So to see if that option was turned on, we have to check for membership of '1' in the list, or `1 in toggles`. (Which currently it's reading that `3` and turning on `Normalize Prompt Weights` because `3` evaluates to true, or maybe it'll just crash somewhere)

It's also possible to change the checkbox group to send data by value, so we'd do this:
`gr.CheckboxGroup(label='', choices=img2img_toggles, value=img2img_toggle_defaults, type="value"),`
and then we'd read `toggles` like
```
    prompt_matrix = 'Create prompt matrix (separate multiple prompts using |, and get all combinations of them)' in toggles
    normalize_prompt_weights = 'Normalize Prompt Weights (ensure sum of weights add up to 1.0)' in toggles
    loopback = 'Loopback (use images from previous batch when creating next batch)' in toggles
...
```
but that seems messier to me, like how someone slightly changing the UI text would silently break stuff.

Sorry for the other bugs. In one spot I forgot a comma, and I also forgot to fix the img2img_toggles/txt2img_toggles var names somehow, which didn't crash because I was still putting off installing GFPGAN at that point.