### PR TITLE
add '--gpu' argument + memory monitor "fix" for AMD

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -117,15 +117,19 @@ def crash(e, s):
 class MemUsageMonitor(threading.Thread):
     stop_flag = False
     max_usage = 0
-    total = 0
+    total = -1
 
     def __init__(self, name):
         threading.Thread.__init__(self)
         self.name = name
 
     def run(self):
+        try:
+            pynvml.nvmlInit()
+        except:
+            print(f"[{self.name}] Unable to initialize NVIDIA management. No memory stats. \n")
+            return
         print(f"[{self.name}] Recording max memory usage...\n")
-        pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(opt.gpu)
         self.total = pynvml.nvmlDeviceGetMemoryInfo(handle).total
         while not self.stop_flag:

--- a/webui.py
+++ b/webui.py
@@ -67,6 +67,8 @@ parser.add_argument("--gpu", type=int, help="choose which GPU to use if you have
 parser.add_argument("--cli", type=str, help="don't launch web server, take Python function kwargs from this file.", default=None)
 opt = parser.parse_args()
 
+# this should force GFPGAN and RealESRGAN onto the selected gpu as well
+os.environ["CUDA_VISIBLE_DEVICES"] = opt.gpu
 GFPGAN_dir = opt.gfpgan_dir
 RealESRGAN_dir = opt.realesrgan_dir
 


### PR DESCRIPTION
* feature: Add `--gpu` argument for choosing which GPU to use (by index)
  * Possibly fixes #67 (haven't tested extensively)
* fix: Make memory monitoring code fail gracefully and prevent causing a divide by zero error with a default of `-1` for the total
  * Fixes #75 
* Remove duplicated `MemUsageMonitor` class