### PR TITLE
Fixed setting environmental variable on Linux

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -68,7 +68,7 @@ parser.add_argument("--cli", type=str, help="don't launch web server, take Pytho
 opt = parser.parse_args()
 
 # this should force GFPGAN and RealESRGAN onto the selected gpu as well
-os.environ["CUDA_VISIBLE_DEVICES"] = opt.gpu
+os.environ["CUDA_VISIBLE_DEVICES"] = str(opt.gpu)
 GFPGAN_dir = opt.gfpgan_dir
 RealESRGAN_dir = opt.realesrgan_dir
 


### PR DESCRIPTION
When running the master branch on Linux I get the following error:
```
Traceback (most recent call last):
  File "/home/johannesg/Projects/waifu-diffusion/../stable-diffusion-webui/webui.py", line 71, in <module>
    os.environ["CUDA_VISIBLE_DEVICES"] = opt.gpu
  File "/usr/lib/python3.10/os.py", line 684, in __setitem__
    value = self.encodevalue(value)
  File "/usr/lib/python3.10/os.py", line 756, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not int
```

This seems to be because the script is setting an int as an environmental variable.
The problem can be fixed by simply casting the int to str before setting.
I'm assuming this is not an issue on Windows (I have no Windows testing environment set up).