### PR TITLE
Fix seed conversion

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -305,9 +305,9 @@ def seed_to_int(s):
     if type(s) is int:
         return s
     if s is None or s == '':
-        return random.randint(0,2**32)
-    n = abs(int(s) if s.isdigit() else hash(s))
-    while n > 2**32:
+        return random.randint(0, 2**32 - 1)
+    n = abs(int(s) if s.isdigit() else random.Random(s).randint(0, 2**32 - 1))
+    while n >= 2**32:
         n = n >> 32
     return n
 


### PR DESCRIPTION
Max value for a 32bit unsigned int is 2**32 - 1, not 2**32 (and the
range of possible values returned by randint includes both of its
arguments).

Python's hash() function is not deterministic across different
invocations of the interpreter. This meant a given string seed would
produce different results after restarting the script. Use the passed
strings to seed a Random instance instead.
