### PR TITLE
Added --grid-format command-line arg

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1612,7 +1612,6 @@ class ServerLauncher(threading.Thread):
     def run(self):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-
         gradio_params = {
             'show_error': True, 
             'server_name': '0.0.0.0', 

--- a/webui.py
+++ b/webui.py
@@ -24,6 +24,9 @@ parser.add_argument("--extra-models-cpu", action='store_true', help="run extra m
 parser.add_argument("--esrgan-cpu", action='store_true', help="run ESRGAN on cpu", default=False)
 parser.add_argument("--gfpgan-cpu", action='store_true', help="run GFPGAN on cpu", default=False)
 parser.add_argument("--cli", type=str, help="don't launch web server, take Python function kwargs from this file.", default=None)
+parser.add_argument("--gradio-port", type=int, help="set Gradio server port", default=7860)
+parser.add_argument("--gradio-auth", type=str, help='set Gradio authentication like "username:password"; or comma-delimit multiple like "u1:p1,u2:p2,u3:p3"', default=None)
+parser.add_argument("--gradio-name", type=str, help="set Gradio server name; the default of '0.0.0.0' will allow the web UI to be accessed outside of the local network (provided firewall/port forwarding is set up)", default='0.0.0.0')
 opt = parser.parse_args()
 
 # this should force GFPGAN and RealESRGAN onto the selected gpu as well
@@ -1544,7 +1547,12 @@ class ServerLauncher(threading.Thread):
     def run(self):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        self.demo.launch(show_error=True, server_name='0.0.0.0')
+
+        auth = opt.gradio_auth
+        if auth is not None:
+            auth = [tuple(cred.split(':')) for cred in auth.strip('"').split(',')]
+
+        self.demo.launch(show_error=True, server_port=opt.gradio_port, auth=auth, server_name=opt.gradio_name)
 
     def stop(self):
         self.demo.close() # this tends to hang


### PR DESCRIPTION
Looks like someone else beat me to the Gradio args coincidentally, so I just cut my version.

Added command-line argument:
- --grid-format [png | jpg:quality | webp:quality (lossy) or webp:-compression (lossless)]
	- accepts inputs like:
		- png (lossless png)
		- jpg:80 (lower-quality jpg)
		- webp:90 (lossy webp, quality scale 90)
		- webp:-100 (lossless webp, max compression)
	- also changed default quality from jpg:100 to jpg:95, mostly because the [Pillow documentation](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg) says to use 0-95, and specifically warns against using 100

Wasn't really sure where to put this code, I didn't want to bloat up the UI any more (especially with at least 2 different forks working on overhauling it atm), and some anons were talking about adding a settings panel anyway.
For now it's up near the top and just sets a few globals that get read in process_images() and img2img(). If we get a settings UI, the code for this should be trivial to excise/repurpose (lazy mode: just move the little parser into a function, with the setting set via a text box using the same format).

Also fixed a bug where the use_RealESRGAN toggle wouldn't work if GFPGAN wasn't installed, because of the toggle indicies getting shifted. Gonna get messy if we add any more conditional toggles...