### PR TITLE
Allow unicode in YAML info dicts

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -561,7 +561,7 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
             info_dict["denoising_strength"] = denoising_strength
             info_dict["resize_mode"] = resize_mode
         with open(f"{filename_i}.yaml", "w", encoding="utf8") as f:
-            yaml.dump(info_dict, f)
+            yaml.dump(info_dict, f, allow_unicode=True)
 
 
 def get_next_sequence_number(path, prefix=''):


### PR DESCRIPTION
On master unicode characters get dumped as something like `\u4EBA` when writing info files.
This PR sets a flag that dumps the actual unicode characters.