### PR TITLE
Fix regular prompt matrix

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -834,7 +834,7 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
 
         if (prompt_matrix or not skip_grid) and not do_not_save_grid:
             if prompt_matrix:
-                grid = image_grid(output_images, batch_size, force_n_rows=1 << ((len(prompt_matrix_parts)-1)//2), captions=prompt_matrix_parts)
+                grid = image_grid(output_images, batch_size, force_n_rows=1 << ((len(prompt_matrix_parts)-1)//2), captions=prompt_matrix_parts if prompt.startswith("@") else None)
             else:
                 grid = image_grid(output_images, batch_size)
 


### PR DESCRIPTION
Commit 82770bacae08f3b41a0df3eee9fca214d6b7fae6 broke regular prompt
matrix, causing the following error:

    Traceback (most recent call last):
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/gradio/routes.py", line 247, in run_predict
        output = await app.blocks.process_api(
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/gradio/blocks.py", line 641, in process_api
        predictions, duration = await self.call_function(fn_index, processed_input)
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/gradio/blocks.py", line 556, in call_function
        prediction = await anyio.to_thread.run_sync(
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync
        return await get_asynclib().run_sync_in_worker_thread(
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
        return await future
      File "/.../sd/miniconda3/envs/ldx/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
        result = context.run(func, *args)
      File "scripts/webui.py", line 933, in txt2img
        output_images, seed, info, stats = process_images(
      File "scripts/webui.py", line 841, in process_images
        grid = image_grid(output_images, batch_size, force_n_rows=1 << ((len(prompt_matrix_parts)-1)//2), captions=prompt_matrix_parts)
      File "scripts/webui.py", line 384, in image_grid
        size = d.textbbox( (0,0), captions[i], font=fnt, stroke_width=2, align="center" )
    IndexError: list index out of range
