### PR TITLE
Revert bad fix for #112

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -584,7 +584,7 @@ def get_next_sequence_number(path, prefix=''):
 
     The sequence starts at 0.
     """
-    result = 0
+    result = -1
     for p in Path(path).iterdir():
         if p.name.endswith(('.png', '.jpg')) and p.name.startswith(prefix):
             tmp = p.name[len(prefix):]


### PR DESCRIPTION
The negative filename reported in #112 was caused by the old (now
replaced) listdir-based sequence number calculation, that incorrectly
subtracted 1 from the number of files already in the directory:

    base_count = len([x for x in os.listdir(sample_path_i) if x.endswith(('.png', '.jpg'))]) - 1 # start at 0

The `- 1` was probably copied from the code for the base directory,
which had to subtract 1 to account for the `samples/` subdirectory (that
was before the listdir code started checking file extensions).

The get_next_sequence_number could never return negative numbers, since
it returns `result + 1`, meaning the sequence starts at 0 as intended.
