### PR TITLE
Revamped output info area

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1516,24 +1516,22 @@ with gr.Blocks(css=css, analytics_enabled=False, title="Stable Diffusion WebUI")
                     txt2img_batch_count = gr.Slider(minimum=1, maximum=250, step=1, label='Batch count (how many batches of images to generate)', value=txt2img_defaults['n_iter'])
                     txt2img_batch_size = gr.Slider(minimum=1, maximum=8, step=1, label='Batch size (how many images are in a batch; memory-hungry)', value=txt2img_defaults['batch_size'])
                 with gr.Column():
-                    with gr.Group():
-                        output_txt2img_gallery = gr.Gallery(label="Images", elem_id="gallery_output").style(grid=[4,4])
-                        gr.Markdown('Selected image actions:')
-                        output_txt2img_copy_clipboard = gr.Button("Copy to clipboard").click(fn=None, inputs=output_txt2img_gallery, outputs=[], _js=copy_selected_img_js)
-                        output_txt2img_copy_to_input_btn = gr.Button("Push to img2img")
-                        if RealESRGAN is not None:
-                            output_txt2img_to_upscale_esrgan = gr.Button("Upscale w/ ESRGAN")                    
-                    with gr.Row():
-                        with gr.Group():
-                            output_txt2img_seed = gr.Number(label='Seed', interactive=False)
-                            output_txt2img_copy_seed = gr.Button("Copy").click(inputs=output_txt2img_seed, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
-                        with gr.Group():
-                            output_txt2img_select_image = gr.Number(label='Image # and click Copy to copy to img2img', value=1, precision=None)
-                            output_txt2img_copy_to_input_btn = gr.Button("Push to img2img", full_width=True)
-                    with gr.Group():
-                        output_txt2img_params = gr.Textbox(label="Copy-paste generation parameters", interactive=False)
-                        output_txt2img_copy_params = gr.Button("Copy").click(inputs=output_txt2img_params, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
-                    output_txt2img_stats = gr.HTML(label='Stats')
+                    output_txt2img_gallery = gr.Gallery(label="Images", elem_id="gallery_output").style(grid=[4,4])
+                    with gr.Tabs():
+                        with gr.TabItem("Generated image actions", id="text2img_actions_tab"):
+                            gr.Markdown('Select an image from the gallery, then click one of the buttons below to perform an action.')
+                            with gr.Row():
+                                output_txt2img_copy_clipboard = gr.Button("Copy to clipboard").click(fn=None, inputs=output_txt2img_gallery, outputs=[], _js=copy_selected_img_js)
+                                output_txt2img_copy_to_input_btn = gr.Button("Push to img2img")
+                                if RealESRGAN is not None:
+                                    output_txt2img_to_upscale_esrgan = gr.Button("Upscale w/ ESRGAN")
+                        with gr.TabItem("Output Info", id="text2img_output_info_tab"):
+                            output_txt2img_params = gr.Textbox(label="Generation parameters", interactive=False)
+                            with gr.Row():
+                                output_txt2img_copy_params = gr.Button("Copy full parameters").click(inputs=output_txt2img_params, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
+                                output_txt2img_seed = gr.Number(label='Seed', interactive=False, visible=False)
+                                output_txt2img_copy_seed = gr.Button("Copy only seed").click(inputs=output_txt2img_seed, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
+                            output_txt2img_stats = gr.HTML(label='Stats')
                 with gr.Column():
                     txt2img_btn = gr.Button("Generate", elem_id="generate", variant="primary")
                     txt2img_steps = gr.Slider(minimum=1, maximum=250, step=1, label="Sampling Steps", value=txt2img_defaults['ddim_steps'])
@@ -1599,12 +1597,18 @@ with gr.Blocks(css=css, analytics_enabled=False, title="Stable Diffusion WebUI")
                     
                 with gr.Column():
                     output_img2img_gallery = gr.Gallery(label="Images")
-                    output_img2img_select_image = gr.Number(label='Select image number from results for copying', value=1, precision=None)
-                    gr.Markdown("Clear the input image before copying your output to your input. It may take some time to load the image.")
-                    output_img2img_copy_to_input_btn = gr.Button("Copy selected image to input")
-                    output_img2img_seed = gr.Number(label='Seed')
-                    output_img2img_params = gr.Textbox(label="Copy-paste generation parameters")
-                    output_img2img_stats = gr.HTML(label='Stats')
+                    with gr.Tabs():
+                        with gr.TabItem("Generated image actions", id="img2img_actions_tab"):
+                            output_img2img_select_image = gr.Number(label='Select image number from results for copying', value=1, precision=None)
+                            gr.Markdown("Clear the input image before copying your output to your input. It may take some time to load the image.")
+                            output_img2img_copy_to_input_btn = gr.Button("Copy selected image to input")
+                        with gr.TabItem("Output info", id="img2img_output_info_tab"):
+                            output_img2img_params = gr.Textbox(label="Generation parameters")
+                            with gr.Row():
+                                output_img2img_copy_params = gr.Button("Copy full parameters").click(inputs=output_img2img_params, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
+                                output_img2img_seed = gr.Number(label='Seed', interactive=False, visible=False)
+                                output_img2img_copy_seed = gr.Button("Copy only seed").click(inputs=output_img2img_seed, outputs=[], _js='(x) => navigator.clipboard.writeText(x)', fn=None, show_progress=False)
+                            output_img2img_stats = gr.HTML(label='Stats')
 
             img2img_image_editor_mode.change(
                 change_image_editor_mode,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1278331/187081476-d0aaefe1-54f3-4baf-b920-06aafdc5575f.png)

![image](https://user-images.githubusercontent.com/1278331/187081473-0f7d0f65-ef20-40ce-8bae-94400ca9570c.png)

Revamped the layout for the output info and actions area.


Indirectly fixes #192 