### PR TITLE
fix(css): prevent generate button from overlapping prompt

### DIFF
--- a/frontend/css_and_js.py
+++ b/frontend/css_and_js.py
@@ -10,22 +10,15 @@ def css(opt):
     [data-testid="image"] {min-height: 512px !important}
     * #body>.col:nth-child(2){width:250%;max-width:89vw}
     
-    #prompt_row input{
-     font-size:20px
+    #prompt_row input,
+    #prompt_row textarea {
+      font-size: 1.5rem;
+      line-height: 2rem;
     }
     #edit_mode_select{width:auto !important}
     input[type=number]:disabled { -moz-appearance: textfield;+ }
-    #generate, #img2img_mask_btn,#img2img_edit_btn{
-        position: absolute;
-        right: 16px;
-        top: 14px;
-    }
-    @media (max-width: 420px){
-        #generate, #img2img_mask_btn,#img2img_edit_btn{
-            position: absolute;
-            right: 16px;
-            top: 5px;
-        }
+    #generate, #img2img_mask_btn, #img2img_edit_btn {
+        height: 100%;
     }
     """
     return styling if opt.no_progressbar_hiding else styling + css_hide_progressbar

--- a/frontend/css_and_js.py
+++ b/frontend/css_and_js.py
@@ -10,15 +10,23 @@ def css(opt):
     [data-testid="image"] {min-height: 512px !important}
     * #body>.col:nth-child(2){width:250%;max-width:89vw}
     
+    #prompt_row {
+        position: relative;
+    }
+
     #prompt_row input,
     #prompt_row textarea {
       font-size: 1.5rem;
       line-height: 2rem;
+      padding-right: 115px;
     }
     #edit_mode_select{width:auto !important}
     input[type=number]:disabled { -moz-appearance: textfield;+ }
     #generate, #img2img_mask_btn, #img2img_edit_btn {
-        height: 100%;
+        position: absolute;
+        top: 15px;
+        bottom: 15px;
+        right: 17px;
     }
     """
     return styling if opt.no_progressbar_hiding else styling + css_hide_progressbar


### PR DESCRIPTION
* Prevent generate button from overlapping prompt text input
* Make multiline prompts match single line prompt styles

## Before:

### Generate button overlapping long prompts

![image](https://user-images.githubusercontent.com/2250252/187128616-aabc4db8-caf5-4d37-81b2-a1ccaaa15456.png)

### Multi-line prompts not matching styles

![image](https://user-images.githubusercontent.com/2250252/187128702-f80e1181-b4a3-4f14-bfed-c8fcdd125586.png)

## After:

### txt2img (single)

![image](https://user-images.githubusercontent.com/2250252/187128159-6b1b8c31-38cd-4dd1-b768-61ad0e967b4c.png)

### txt2img (multiline)

![image](https://user-images.githubusercontent.com/2250252/187128198-4c121108-1dfd-4cc2-a9ed-2a1a4b944e32.png)

### img2img
![image](https://user-images.githubusercontent.com/2250252/187128292-cff87641-5926-486e-9bff-d8efbc15b4bd.png)
