### PR TITLE
refactor: decouple python from js and css

### DIFF
--- a/frontend/css/no_progress_bar.css
+++ b/frontend/css/no_progress_bar.css
@@ -1,0 +1,4 @@
+.wrap .m-12 svg { display:none!important; }
+.wrap .m-12::before { content:"Loading..." }
+.progress-bar { display:none!important; }
+.meta-text { display:none!important; }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,0 +1,21 @@
+[data-testid="image"] {min-height: 512px !important}
+* #body>.col:nth-child(2){width:250%;max-width:89vw}
+
+#prompt_input, #img2img_prompt_input {
+    padding: 0px;
+    border: none;
+}
+
+#prompt_row input,
+#prompt_row textarea {
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+}
+
+#edit_mode_select{width:auto !important}
+
+input[type=number]:disabled { -moz-appearance: textfield;+ }
+
+#generate, #img2img_mask_btn, #img2img_edit_btn {
+    align-self: stretch;
+}

--- a/frontend/css_and_js.py
+++ b/frontend/css_and_js.py
@@ -1,67 +1,38 @@
+import os
+from os import path
+
+def readTextFile(*args):
+    dir = os.path.dirname(__file__)
+    entry = os.path.join(dir, *args)
+    with open(entry, "r", encoding="utf8") as f:
+        data = f.read()
+    return data
+
 def css(opt):
-    css_hide_progressbar = """
-    .wrap .m-12 svg { display:none!important; }
-    .wrap .m-12::before { content:"Loading..." }
-    .progress-bar { display:none!important; }
-    .meta-text { display:none!important; }
-    """
-    styling = """
-    
-    [data-testid="image"] {min-height: 512px !important}
-    * #body>.col:nth-child(2){width:250%;max-width:89vw}
+    styling = readTextFile("css", "styles.css")
+    if not opt.no_progressbar_hiding:
+        styling += readTextFile("css", "no_progress_bar.css")
+    return styling
 
-    #prompt_input, #img2img_prompt_input { 
-        padding: 0px;
-        border: none;
-    }
+def js(opt):
+    data = readTextFile("js", "index.js")
+    data = "(z) => {" + data + "; return z ?? [] }"
+    return data
 
-    #prompt_row input,
-    #prompt_row textarea {
-        font-size: 1.2rem;
-        line-height: 1.6rem;
-    }
+# Wrap the typical SD method call into async closure for ease of use
+# If you call frontend method without wrapping
+# DONT FORGET to bind input argument if you need it: SD.with(x)
+def w(sd_method_call):
+    return f"async (x) => {{ return await SD.with(x).{sd_method_call} ?? x ?? []; }}"
 
-    #edit_mode_select{width:auto !important}
+def js_move_image(from_id, to_id):
+    return w(f"moveImageFromGallery('{from_id}', '{to_id}')")
 
-    input[type=number]:disabled { -moz-appearance: textfield;+ }
+def js_copy_to_clipboard(from_id):
+    return w(f"copyImageFromGalleryToClipboard('{from_id}')")
 
-    #generate, #img2img_mask_btn, #img2img_edit_btn {
-        align-self: stretch;
-    }
-    """
-    return styling if opt.no_progressbar_hiding else styling + css_hide_progressbar
+def js_painterro_launch():
+    return w("Painterro.init(SD.x)")
 
-# This is the code that finds which selected item the user has in the gallery
-js_part_getindex_txt2img="""
-const root = document.querySelector('gradio-app').shadowRoot;
-const getIndex = function(){
-const selected = root.querySelector('#txt2img_gallery_output .\\\\!ring-2');
-return selected ? [...selected.parentNode.children].indexOf(selected) : 0;
-};"""
-js_part_getindex_img2img="""
-const root = document.querySelector('gradio-app').shadowRoot;
-const getIndex = function(){
-    const selected = root.querySelector('#img2img_gallery_output .\\\\!ring-2');
-    return selected ? [...selected.parentNode.children].indexOf(selected) : 0;
-};"""
-js_part_clear_img2img="""
-root.querySelector('#img2img_editor .modify-upload button:last-child')?.click();
-
-
-"""
-js_return_selected_txt2img = "(x) => {" + js_part_getindex_txt2img + js_part_clear_img2img + """
-return [x[getIndex()].replace('data:;','data:image/png;')];
-}"""
-js_return_selected_img2img = "(x) => {" + js_part_getindex_img2img + js_part_clear_img2img + """
-return [x[getIndex()].replace('data:;','data:image/png;')];
-}"""
-
-js_part_copy_to_clipboard="""
-const data = x[getIndex()];
-const blob = await (await fetch(data.replace('data:;','data:image/png;'))).blob(); 
-const item = new ClipboardItem({'image/png': blob});
-navigator.clipboard.write([item]);
-return x;
-}"""
-js_copy_selected_txt2img = "async (x) => {" + js_part_getindex_txt2img + js_part_copy_to_clipboard
-js_copy_selected_img2img = "async (x) => {" + js_part_getindex_img2img + js_part_copy_to_clipboard
+def js_painterro_load_image(to_id):
+    return w(f"Painterro.loadImage('{to_id}')")

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -136,6 +136,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                                                              value="Crop", elem_id='edit_mode_select')
 
                             img2img_painterro_btn = gr.Button("Advanced Editor")
+                            img2img_copy_from_painterro_btn = gr.Button(value="Get Image from Advanced Editor")
                             img2img_show_help_btn = gr.Button("Show Hints")
                             img2img_hide_help_btn = gr.Button("Hide Hints", visible=False)
                         img2img_help = gr.Markdown(visible=False, value="")
@@ -220,7 +221,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                     uifn.change_image_editor_mode,
                     [img2img_image_editor_mode, img2img_image_editor, img2img_resize, img2img_width, img2img_height],
                     [img2img_image_editor, img2img_image_mask, img2img_btn_editor, img2img_btn_mask,
-                     img2img_painterro_btn, img2img_mask, img2img_mask_blur_strength]
+                     img2img_painterro_btn, img2img_copy_from_painterro_btn, img2img_mask, img2img_mask_blur_strength]
                 )
 
                 img2img_image_editor.edit(

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -1,0 +1,92 @@
+window.SD = (() => {
+  class PainterroClass {
+    static init (img) {
+      Painterro({
+        hiddenTools: ['arrow'],
+        saveHandler: function (image, done) {
+          localStorage.setItem('painterro-image', image.asDataURL());
+          done(true);
+        },
+      }).show(Array.isArray(img) ? img[0] : img);
+    }
+    static loadImage (toId) {
+      window.SD.clearImageInput(window.SD.el.get(`#${toId}`));
+
+      const image = localStorage.getItem('painterro-image')
+      return [image, image];
+    }
+  }
+
+  /*
+   * Turns out caching elements doesn't actually work in gradio
+   * As elements in tabs might get recreated
+   */
+  class ElementCache {
+    #el;
+    constructor () {
+      this.root = document.querySelector('gradio-app').shadowRoot;
+    }
+    get (selector) {
+      return this.root.querySelector(selector);
+    }
+  }
+
+  /*
+   * The main helper class to incapsulate functions
+   * that change gradio ui functionality
+   */
+  class SD {
+    el = new ElementCache();
+    x;
+    Painterro = PainterroClass;
+    with (x) {
+      this.x = x;
+      return this;
+    }
+    moveImageFromGallery (fromId, toId) {
+      if (!Array.isArray(this.x) || this.x.length === 0) return;
+
+      this.clearImageInput(this.el.get(`#${toId}`));
+
+      const i = this.#getGallerySelectedIndex(this.el.get(`#${fromId}`));
+
+      return [this.x[i].replace('data:;','data:image/png;')];
+    }
+    async copyImageFromGalleryToClipboard (fromId) {
+      if (!Array.isArray(this.x) || this.x.length === 0) return;
+
+      const i = this.#getGallerySelectedIndex(this.el.get(`#${fromId}`));
+
+      const data = this.x[i];
+      const blob = await (await fetch(data.replace('data:;','data:image/png;'))).blob();
+      const item = new ClipboardItem({'image/png': blob});
+
+      try {
+        navigator.clipboard.write([item]);
+      } catch (e) {
+        // TODO: graceful error messaing
+        console.error(e);
+        alert(e.message);
+      }
+
+      return this.x;
+    }
+    clearImageInput (imageEditor) {
+      imageEditor?.querySelector('.modify-upload button:last-child')?.click();
+    }
+    #getGallerySelectedIndex (gallery) {
+      const selected = gallery.querySelector(`.\\!ring-2`);
+      return selected ? [...selected.parentNode.children].indexOf(selected) : 0;
+    }
+  }
+
+  // Painterro stuff
+  const script = document.createElement('script');
+  script.src = 'https://unpkg.com/painterro@1.2.78/build/painterro.min.js';
+  document.head.appendChild(script);
+  const style = document.createElement('style');
+  style.appendChild(document.createTextNode('.ptro-holder-wrapper { z-index: 9999 !important; }'));
+  document.head.appendChild(style);
+
+  return new SD();
+})();

--- a/frontend/ui_functions.py
+++ b/frontend/ui_functions.py
@@ -64,9 +64,7 @@ help_text = """
     * If the mask appears distorted (the brush is weirdly shaped instead of round), switch back to Crop and then back again to Mask.
 
     ## Advanced Editor
-    * For now the button needs to be clicked twice the first time.
     * Once you have edited your image, you _need_ to click the save button for the next step to work.
-    * Clear the image from the crop editor (click the x)
     * Click "Get Image from Advanced Editor" to get the image you saved. If it doesn't work, try opening the editor and saving again.
 
     If it keeps not working, try switching modes again, switch tabs, clear the image or reload.


### PR DESCRIPTION
This is a large change that concerns `frontend` folder.
 In short `css_and_js.py` was refactored to be a facade for frontend files which are stored in their respective folders: `css` and `js`.

Currently the implementation is very simple. It bundles together css files based on ops and js is just one big file that exposes SD object to the global space. At a later date it can be expanded as needed while maintaining a simple interface with python scripts via `css_and_js.py`.

I tested it to my ability but the changes are vast so I might have missed a few things.

**IMPORTANT NOTES**
1. To load the js on load event I currently use a hack with invisible element. This is only temporary until the next gradio version is released. My PR has already been merged into master there: gradio-app/gradio#2108 
2. Calls to js functions depend on ids of the relevant components. Those should be made into dictionary or something like that instead of just string literals.
3. I had to remove the changes made in 7ddbd6533a03b3abd513462dacc676640b8499c0 in order to push. I will try to incorporate them later.