### PR TITLE
FIx simple tmpl image grid. Detach from orig grid

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -421,7 +421,7 @@ def image_grid(imgs, batch_size, force_n_rows=None, captions=None):
 
     for i, img in enumerate(imgs):
         grid.paste(img, box=(i % cols * w, i // cols * h))
-        if captions:
+        if captions and i<len(captions):
             d = ImageDraw.Draw( grid )
             size = d.textbbox( (0,0), captions[i], font=fnt, stroke_width=2, align="center" )
             d.multiline_text((i % cols * w + w/2, i // cols * h + h - size[3]), captions[i], font=fnt, fill=(255,255,255), stroke_width=2, stroke_fill=(0,0,0), anchor="mm", align="center")
@@ -711,8 +711,12 @@ def process_images(
     comments = []
 
     prompt_matrix_parts = []
+    simple_templating = False
+    add_original_image = True
     if prompt_matrix:
         if prompt.startswith("@"):
+            simple_templating = True
+            add_original_image = not (use_RealESRGAN or use_GFPGAN)
             all_seeds, n_iter, prompt_matrix_parts, all_prompts, frows = oxlamon_matrix(prompt, seed, n_iter, batch_size)
         else:
             all_prompts = []
@@ -746,6 +750,7 @@ def process_images(
 
     precision_scope = autocast if opt.precision == "autocast" else nullcontext
     output_images = []
+    grid_captions = []
     stats = []
     with torch.no_grad(), precision_scope("cuda"), (model.ema_scope() if not opt.optimized else nullcontext()):
         init_data = func_init()
@@ -767,6 +772,7 @@ def process_images(
         for n in range(n_iter):
             print(f"Iteration: {n+1}/{n_iter}")
             prompts = all_prompts[n * batch_size:(n + 1) * batch_size]
+            captions = prompt_matrix_parts[n * batch_size:(n + 1) * batch_size]
             seeds = all_seeds[n * batch_size:(n + 1) * batch_size]
 
             if opt.optimized:
@@ -859,6 +865,8 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
 normalize_prompt_weights, use_GFPGAN, write_info_files, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
 skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode)
                     output_images.append(gfpgan_image) #287
+                    if simple_templating:
+                        grid_captions.append( captions[i] + "\ngfpgan" )
 
                 if use_RealESRGAN and RealESRGAN is not None and not use_GFPGAN:
                     skip_save = True # #287 >_>
@@ -876,6 +884,8 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
 normalize_prompt_weights, use_GFPGAN, write_info_files, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
 skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode)
                     output_images.append(esrgan_image) #287
+                    if simple_templating:
+                        grid_captions.append( captions[i] + "\nesrgan" )
 
                 if use_RealESRGAN and RealESRGAN is not None and use_GFPGAN and GFPGAN is not None:
                     skip_save = True # #287 >_>
@@ -895,13 +905,17 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
 normalize_prompt_weights, use_GFPGAN, write_info_files, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
 skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode)
                     output_images.append(gfpgan_esrgan_image) #287
+                    if simple_templating:
+                        grid_captions.append( captions[i] + "\ngfpgan_esrgan" )
 
                 if not skip_save or (not use_GFPGAN or not use_RealESRGAN):
-
                     save_sample(image, sample_path_i, filename, jpg_sample, prompts, seeds, width, height, steps, cfg_scale, 
 normalize_prompt_weights, use_GFPGAN, write_info_files, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
 skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode)
-                    output_images.append(image)
+                    if add_original_image or not simple_templating:
+                        output_images.append(image)
+                        if simple_templating:
+                            grid_captions.append( captions[i] )
 
                 if opt.optimized:
                     mem = torch.cuda.memory_allocated()/1e6
@@ -911,8 +925,8 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
 
         if (prompt_matrix or not skip_grid) and not do_not_save_grid:
             if prompt_matrix:
-                if prompt.startswith("@"):
-                    grid = image_grid(output_images, batch_size, force_n_rows=frows, captions=prompt_matrix_parts)
+                if simple_templating:
+                    grid = image_grid(output_images, batch_size, force_n_rows=frows, captions=grid_captions)
                 else:
                     grid = image_grid(output_images, batch_size, force_n_rows=1 << ((len(prompt_matrix_parts)-1)//2))
                     try:


### PR DESCRIPTION
- fixed out of range for simple templating and original templating
- fixed out of range error in image_grid (and before)
- fixed captions for simple templating grid BUT

all these errors were due to differences in len(output_images) and len(prompt_matrix_parts) because the additional data (GFPGAN/RealESRGAN images) was added to the output_images but not in prompt_matrix_parts. thas why i was added new array (for now only to simple templating)

* I recommend adding additional checkboxes or combobox (something like `no grid|simple grid|original grid` - *you name it) it would be great