### PR TITLE
bugfix: on submit prompt event in img2img

### DIFF
--- a/frontend/css_and_js.py
+++ b/frontend/css_and_js.py
@@ -33,3 +33,5 @@ def js_copy_to_clipboard(from_id):
 def js_painterro_launch(to_id):
     return w(f"Painterro.init('{to_id}')")
 
+def js_img2img_submit(prompt_row_id):
+    return w(f"clickFirstVisibleButton('{prompt_row_id}')")

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -287,7 +287,10 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                      img2img_embeddings],
                     [output_img2img_gallery, output_img2img_seed, output_img2img_params, output_img2img_stats])
                 img2img_btn_editor.click(*img2img_submit_params())
-                img2img_prompt.submit(*img2img_submit_params())
+
+                # GENERATE ON ENTER
+                img2img_prompt.submit(None, None, None,
+                                      _js=js_img2img_submit("prompt_row"))
 
                 img2img_painterro_btn.click(None, [img2img_image_editor], [img2img_image_editor, img2img_image_mask], _js=js_painterro_launch('img2img_editor'))
 

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -131,6 +131,22 @@ window.SD = (() => {
     clearImageInput (imageEditor) {
       imageEditor?.querySelector('.modify-upload button:last-child')?.click();
     }
+    clickFirstVisibleButton(rowId) {
+      const generateButtons = this.el.get(`#${rowId}`).querySelectorAll('.gr-button-primary');
+
+      if (!generateButtons) return;
+
+      for (let i = 0, arr = [...generateButtons]; i < arr.length; i++) {
+        const cs = window.getComputedStyle(arr[i]);
+
+        if (cs.display !== 'none' && cs.visibility !== 'hidden') {
+          console.log(arr[i]);
+
+          arr[i].click();
+          break;
+        }
+      }
+    }
     static error (e) {
       console.error(e);
       if (typeof e === 'string') {


### PR DESCRIPTION
Following the discussion in #313 there is indeed a bug in [submit event](https://github.com/hlky/stable-diffusion/blob/2cb47b6a2ca64c08d1e0b6734a234cc57f37b23c/frontend/frontend.py#L290). It only assumes that the img2img is in Crop mode so it fails in Mask mode.

The way to fix this would be to check which mode is on but **there  is already another mode button in there** so instead I opted out to a simple js fix.

The code finds the first active generate button and clicks it just like a human would. Nice and easy.