### PR TITLE
fix: minor painterro integration fixes

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -56,21 +56,35 @@ window.SD = (() => {
     static fallback (image) { return [image, image]; }
     static load () {
       return new Promise((resolve, reject) => {
-        /* Ensure Painterro window is always on top */
-        const style = document.createElement('style');
-        style.setAttribute('type', 'text/css');
-        style.appendChild(document.createTextNode(`
-          .ptro-holder-wrapper {
-              z-index: 100;
-          }
-        `));
-        document.head.appendChild(style);
+        const scriptId = '__painterro-script';
+        if (document.getElementById(scriptId)) {
+          reject(new Error('Tried to load painterro script, but script tag already exists.'));
+          return;
+        }
+
+        const styleId = '__painterro-css-override';
+        if (!document.getElementById(styleId)) {
+          /* Ensure Painterro window is always on top */
+          const style = document.createElement('style');
+          style.id = styleId;
+          style.setAttribute('type', 'text/css');
+          style.appendChild(document.createTextNode(`
+            .ptro-holder-wrapper {
+                z-index: 100;
+            }
+          `));
+          document.head.appendChild(style);
+        }
 
         const script = document.createElement('script');
-        script.id = '__painterro-script';
+        script.id = scriptId;
         script.src = 'https://unpkg.com/painterro@1.2.78/build/painterro.min.js';
         script.onload = () => resolve(true);
-        script.onerror = () => reject(false);
+        script.onerror = (e) => {
+          // remove self on error to enable reattempting load
+          document.head.removeChild(script);
+          reject(e);
+        };
         document.head.appendChild(script);
       });
     }


### PR DESCRIPTION
* Prevent multiple script tags from being loaded if the `Advanced Editor` button is pressed rapidly before painterro has been loaded
* Prevent styles from being applied more than once
* Handle painterro script loading errors more gracefully
  * Remove the script tag after an error occurs to allow re-attempts
  * Log the error event instead of `false`
  * (maybe painterro should be served by the webui directly instead to avoid this scenario and improve the offline experience?)