### PR TITLE
Set YAML dump width to 10000

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -580,7 +580,7 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
             info_dict["denoising_strength"] = denoising_strength
             info_dict["resize_mode"] = resize_mode
         with open(f"{filename_i}.yaml", "w", encoding="utf8") as f:
-            yaml.dump(info_dict, f, allow_unicode=True)
+            yaml.dump(info_dict, f, allow_unicode=True, width=10000)
 
 
 def get_next_sequence_number(path, prefix=''):


### PR DESCRIPTION
Currently YAML info file have a relatively low maximum width which introduces line breaks in long prompts.
Since this is annoying for copy-pasting this PR sets the maximum line width to 10000 characters.