### PR TITLE
Add dimensions info (aspect ratio and pixel count)

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -38,6 +38,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                         txt2img_batch_size = gr.Slider(minimum=1, maximum=8, step=1,
                                                        label='Batch size (how many images are in a batch; memory-hungry)',
                                                        value=txt2img_defaults['batch_size'])
+                        txt2img_dimensions_info_text_box = gr.Textbox(label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)")
                     with gr.Column():
                         output_txt2img_gallery = gr.Gallery(label="Images", elem_id="txt2img_gallery_output").style(grid=[4, 4])
 
@@ -113,6 +114,8 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                      txt2img_height, txt2img_width, txt2img_embeddings, txt2img_variant_amount, txt2img_variant_seed],
                     [output_txt2img_gallery, output_txt2img_seed, output_txt2img_params, output_txt2img_stats]
                 )
+                txt2img_width.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
+                txt2img_height.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
 
             with gr.TabItem("Stable Diffusion Image-to-Image Unified", id="img2img_tab"):
                 with gr.Row(elem_id="prompt_row"):
@@ -202,6 +205,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                         img2img_batch_size = gr.Slider(minimum=1, maximum=8, step=1,
                                                        label='Batch size (how many images are in a batch; memory-hungry)',
                                                        value=img2img_defaults['batch_size'])
+                        img2img_dimensions_info_text_box = gr.Textbox(label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)")
                     with gr.Column():
                         img2img_steps = gr.Slider(minimum=1, maximum=250, step=1, label="Sampling Steps",
                                                   value=img2img_defaults['ddim_steps'])
@@ -286,6 +290,9 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                                       _js=js_img2img_submit("prompt_row"))
 
                 img2img_painterro_btn.click(None, [img2img_image_editor], [img2img_image_editor, img2img_image_mask], _js=js_painterro_launch('img2img_editor'))
+
+                img2img_width.change(fn=uifn.update_dimensions_info, inputs=[img2img_width, img2img_height], outputs=img2img_dimensions_info_text_box)
+                img2img_height.change(fn=uifn.update_dimensions_info, inputs=[img2img_width, img2img_height], outputs=img2img_dimensions_info_text_box)
 
             if GFPGAN is not None:
                 gfpgan_defaults = {

--- a/frontend/ui_functions.py
+++ b/frontend/ui_functions.py
@@ -106,3 +106,7 @@ def resize_image(resize_mode, im, width, height):
             res.paste(resized.resize((fill_width, height), box=(resized.width, 0, resized.width, height)), box=(fill_width + src_w, 0))
 
     return res
+
+def update_dimensions_info(width, height):
+    pixel_count_formated = "{:,.0f}".format(width * height)
+    return f"Aspect ratio: {round(width / height, 5)}\nTotal pixel count: {pixel_count_formated}"


### PR DESCRIPTION
Added a text box to show the **aspect ratio** and the **total pixel count** for the input dimensions for txt2img and img2img.
The total pixel count could be helpful to keep within your VRAM limit and prevent "out of memory" errors.
I'll attach a preview of the UI.
If you have any improvements, please go ahead and let me know.

![txt2img_dimensions_info](https://user-images.githubusercontent.com/32816584/187558584-2c46999e-6e8a-462f-8ecb-ee52447f87cb.gif)

![img2img_dimensions_info](https://user-images.githubusercontent.com/32816584/187558593-ba437d57-36cd-4c76-a685-e14b1349caad.gif)
