### PR TITLE
[Feature] Image Processing tab

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -53,7 +53,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                                                                          _js=js_copy_to_clipboard('txt2img_gallery_output'))
                                     output_txt2img_copy_to_input_btn = gr.Button("Push to img2img")
                                     if RealESRGAN is not None:
-                                        output_txt2img_to_upscale_esrgan = gr.Button("Upscale w/ ESRGAN")
+                                        output_txt2img_to_upscale_esrgan = gr.Button("Upscale w/ ESRGAN",visible=False)
 
                             with gr.TabItem("Output Info", id="text2img_output_info_tab"):
                                 output_txt2img_params = gr.Textbox(label="Generation parameters", interactive=False)
@@ -90,7 +90,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                                             choices=['RealESRGAN_x4plus',
                                                                                      'RealESRGAN_x4plus_anime_6B'],
                                                                             value='RealESRGAN_x4plus',
-                                                                            visible=RealESRGAN is not None)  # TODO: Feels like I shouldnt slot it in here.
+                                                                            visible=False)#RealESRGAN is not None # invisible until removed)  # TODO: Feels like I shouldnt slot it in here.
                                 txt2img_ddim_eta = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label="DDIM ETA",
                                                              value=txt2img_defaults['ddim_eta'], visible=False)
                                 txt2img_variant_amount = gr.Slider(minimum=0.0, maximum=1.0, label='Variation Amount',
@@ -318,9 +318,9 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
             <p><b>GoBIG</b></p>
             <p>A 2X upscaler that uses RealESRGAN to upscale the image and then slice it into small parts, each part gets diffused further by SD to create more details, great for adding and increasing details but will change the composition, might also fix issues like eyes etc, use the settings like img2img etc</p>
             <p><b>Latent Diffusion Super Resolution</b></p>
-            <p>A 4x upscaler with high VRAM usage that uses a Latent Diffusion model to upscale the image, this will accentuate the details but won't change the composition, might introduce sharpening, great for textures or compositions with plenty of details</p>
+            <p>A 4X upscaler with high VRAM usage that uses a Latent Diffusion model to upscale the image, this will accentuate the details but won't change the composition, might introduce sharpening, great for textures or compositions with plenty of details, is slower.</p>
             <p><b>GoLatent</b></p>
-            <p>A 8x upscaler with high VRAM usage, uses GoBig to add details and then uses a Latent Diffusion model to upscale the image, this will result in less artifacting/sharpeninng, use the settings to feed GoBig settings that will contribute to the result, this mode is considerbly slower</p>
+            <p>A 8X upscaler with high VRAM usage, uses GoBig to add details and then uses a Latent Diffusion model to upscale the image, this will result in less artifacting/sharpeninng, use the settings to feed GoBig settings that will contribute to the result, this mode is considerbly slower</p>
         </div>
         """)
                         with gr.Column():

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -326,7 +326,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                         with gr.Column():
                             with gr.Tabs():
                                 with gr.TabItem('Output'):
-                                    imgproc_output = gr.Image(label="Output")
+                                    imgproc_output = gr.Gallery(label="Output", elem_id="imgproc_gallery_output")
                             with gr.Row(elem_id="proc_options_row"):
                                 imgproc_toggles = gr.CheckboxGroup(label='Processor Modes', choices=imgproc_mode_toggles, type="index")
                             with gr.Tabs():

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -3,10 +3,10 @@ from frontend.css_and_js import *
 from frontend.css_and_js import css
 import frontend.ui_functions as uifn
 
-def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaults={}, RealESRGAN=True, GFPGAN=True,
+def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda x: x, txt2img_defaults={}, RealESRGAN=True, GFPGAN=True,LDSR=True,
                    txt2img_toggles={}, txt2img_toggle_defaults='k_euler', show_embeddings=False, img2img_defaults={},
                    img2img_toggles={}, img2img_toggle_defaults={}, sample_img2img=None, img2img_mask_modes=None,
-                   img2img_resize_modes=None, user_defaults={}, run_GFPGAN=lambda x: x, run_RealESRGAN=lambda x: x):
+                   img2img_resize_modes=None, imgproc_defaults={},imgproc_mode_toggles={},user_defaults={}, run_GFPGAN=lambda x: x, run_RealESRGAN=lambda x: x):
 
     with gr.Blocks(css=css(opt), analytics_enabled=False, title="Stable Diffusion WebUI") as demo:
         with gr.Tabs(elem_id='tabss') as tabs:
@@ -293,7 +293,122 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
 
                 img2img_width.change(fn=uifn.update_dimensions_info, inputs=[img2img_width, img2img_height], outputs=img2img_dimensions_info_text_box)
                 img2img_height.change(fn=uifn.update_dimensions_info, inputs=[img2img_width, img2img_height], outputs=img2img_dimensions_info_text_box)
+            
+            with gr.TabItem("Image Lab", id='imgproc_tab'):
+                    gr.Markdown("Post-process results")
+                    with gr.Row():
+                        with gr.Column():
+                            with gr.Tabs():
+                                with gr.TabItem('Single Image'):
+                                    imgproc_source = gr.Image(label="Source", source="upload", interactive=True, type="pil")
 
+                            #gfpgan_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Effect strength",
+                            #                            value=gfpgan_defaults['strength'])
+                            #select folder with images to process
+                                with gr.TabItem('Batch Process'):
+                                    imgproc_folder = gr.File(label="Batch Process", file_count="multiple",source="upload", interactive=True, type="file")
+                            with gr.Row():
+                                imgproc_btn = gr.Button("Process", variant="primary")
+                            gr.HTML("""
+        <div id="90" style="max-width: 100%; font-size: 14px; text-align: center;" class="output-markdown gr-prose border-solid border border-gray-200 rounded gr-panel">
+            <p><b>Upscale Modes Guide</b></p>
+            <p></p>
+            <p><b>RealESRGAN</b></p>
+            <p>A 4X/2X fast upscaler that works well for stylized content, will smooth more detailed compositions.</p>
+            <p><b>GoBIG</b></p>
+            <p>A 2X upscaler that uses RealESRGAN to upscale the image and then slice it into small parts, each part gets diffused further by SD to create more details, great for adding and increasing details but will change the composition, might also fix issues like eyes etc, use the settings like img2img etc</p>
+            <p><b>Latent Diffusion Super Resolution</b></p>
+            <p>A 4x upscaler with high VRAM usage that uses a Latent Diffusion model to upscale the image, this will accentuate the details but won't change the composition, might introduce sharpening, great for textures or compositions with plenty of details</p>
+            <p><b>GoLatent</b></p>
+            <p>A 8x upscaler with high VRAM usage, uses GoBig to add details and then uses a Latent Diffusion model to upscale the image, this will result in less artifacting/sharpeninng, use the settings to feed GoBig settings that will contribute to the result, this mode is considerbly slower</p>
+        </div>
+        """)
+                        with gr.Column():
+                            with gr.Tabs():
+                                with gr.TabItem('Output'):
+                                    imgproc_output = gr.Image(label="Output")
+                            with gr.Row(elem_id="proc_options_row"):
+                                imgproc_toggles = gr.CheckboxGroup(label='Processor Modes', choices=imgproc_mode_toggles, type="index")
+                            with gr.Tabs():
+                                with gr.TabItem('Fix Face Settings'):
+                                    gfpgan_defaults = {
+                                        'strength': 100,
+                                    }
+
+                                    if 'gfpgan' in user_defaults:
+                                        gfpgan_defaults.update(user_defaults['gfpgan'])
+                                    if GFPGAN is None:
+                                        gr.HTML("""
+        <div id="90" style="max-width: 100%; font-size: 14px; text-align: center;" class="output-markdown gr-prose border-solid border border-gray-200 rounded gr-panel">
+            <p><b> Please download GFPGAN to activate face fixing features</b>, instructions are available at the <a href='https://github.com/hlky/stable-diffusion-webui'>Github</a></p>
+        </div>
+        """)
+                                        #gr.Markdown("")
+                                        #gr.Markdown("<b> Please download GFPGAN to activate face fixing features</b>, instructions are available at the <a href='https://github.com/hlky/stable-diffusion-webui'>Github</a>")
+                                    imgproc_gfpgan_strength = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Effect strength",
+                                                                value=gfpgan_defaults['strength'],visible=GFPGAN is not None)
+                                with gr.TabItem('Upscale Settings'):
+                                    imgproc_realesrgan_model_name = gr.Dropdown(label='RealESRGAN model', interactive=RealESRGAN is not None,
+                                                                                choices= ['RealESRGAN_x4plus',
+                                                                                        'RealESRGAN_x4plus_anime_6B','RealESRGAN_x2plus',
+                                                                                        'RealESRGAN_x2plus_anime_6B'],
+                                                                                value='RealESRGAN_x4plus',
+                                                                                visible=RealESRGAN is not None)  # TODO: Feels like I shouldnt slot it in here.
+                                    if LDSR:
+                                        upscaleModes = ['RealESRGAN','GoBig','Latent Diffusion SR','GoLatent ']
+                                    else:
+                                        gr.HTML("""
+        <div id="90" style="max-width: 100%; font-size: 14px; text-align: center;" class="output-markdown gr-prose border-solid border border-gray-200 rounded gr-panel">
+            <p><b> Please download LDSR to activate more upscale features</b>, instructions are available at the <a href='https://github.com/hlky/stable-diffusion-webui'>Github</a></p>
+        </div>
+        """)
+                                        upscaleModes = ['RealESRGAN','GoBig','Latent Diffusion SR']
+                                        #gr.Markdown("<b> Please download LDSR to activate more upscale features</b>, instructions are available at the <a href='https://github.com/hlky/stable-diffusion-webui'>Github</a>")
+                                        upscaleModes = ['RealESRGAN','GoBig']
+                                    imgproc_upscale_toggles = gr.Radio(label='Upscale Modes', choices=upscaleModes, type="index",visible=RealESRGAN is not None)
+                                    with gr.Row(elem_id="proc_prompt_row"):
+                                        with gr.Column():
+                                            imgproc_prompt = gr.Textbox(label="These settings are applied only for GoBig and GoLatent modes",
+                                                                        elem_id='prompt_input',
+                                                                        placeholder="A corgi wearing a top hat as an oil painting.",
+                                                                        lines=1,
+                                                                        max_lines=1,
+                                                                        value=imgproc_defaults['prompt'],
+                                                                        show_label=True,
+                                                                        visible=RealESRGAN is not None)
+                                            imgproc_sampling = gr.Dropdown(label='Sampling method (k_lms is default k-diffusion sampler)',
+                                                        choices=["DDIM", 'k_dpm_2_a', 'k_dpm_2', 'k_euler_a', 'k_euler',
+                                                                    'k_heun', 'k_lms'],
+                                                        value=imgproc_defaults['sampler_name'],visible=RealESRGAN is not None)
+                                            imgproc_steps = gr.Slider(minimum=1, maximum=250, step=1, label="Sampling Steps",
+                                                    value=imgproc_defaults['ddim_steps'],visible=RealESRGAN is not None)
+                                            imgproc_cfg = gr.Slider(minimum=1.0, maximum=30.0, step=0.5,
+                                                                    label='Classifier Free Guidance Scale (how strongly the image should follow the prompt)',
+                                                                    value=imgproc_defaults['cfg_scale'],visible=RealESRGAN is not None)
+                                            imgproc_denoising = gr.Slider(minimum=0.0, maximum=1.0, step=0.01, label='Denoising Strength',
+                                                        value=imgproc_defaults['denoising_strength'],visible=RealESRGAN is not None)
+                                            imgproc_height = gr.Slider(minimum=64, maximum=2048, step=64, label="Height",
+                                                            value=imgproc_defaults["height"],visible=False) # not currently implemented
+                                            imgproc_width = gr.Slider(minimum=64, maximum=2048, step=64, label="Width",
+                                                                    value=imgproc_defaults["width"],visible=False) # not currently implemented
+                                            imgproc_seed = gr.Textbox(label="Seed (blank to randomize)", lines=1, max_lines=1,
+                                                                    value=imgproc_defaults["seed"],visible=RealESRGAN is not None)
+                                            imgproc_btn.click(
+                                                        imgproc,
+                                                        [imgproc_source, imgproc_folder,imgproc_prompt,imgproc_toggles,
+                                                        imgproc_upscale_toggles,imgproc_realesrgan_model_name,imgproc_sampling, imgproc_steps, imgproc_height, imgproc_width, imgproc_cfg, imgproc_denoising, imgproc_seed,imgproc_gfpgan_strength],
+                                                        [imgproc_output])
+                                    if RealESRGAN is None:
+                                        with gr.Row():
+                                            with gr.Column():
+                                                #seperator
+                                                gr.HTML("""
+        <div id="90" style="max-width: 100%; font-size: 14px; text-align: center;" class="output-markdown gr-prose border-solid border border-gray-200 rounded gr-panel">
+            <p><b> Please download RealESRGAN to activate upscale features</b>, instructions are available at the <a href='https://github.com/hlky/stable-diffusion-webui'>Github</a></p>
+        </div>
+        """)
+            
+            """
             if GFPGAN is not None:
                 gfpgan_defaults = {
                     'strength': 100,
@@ -339,7 +454,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, txt2img_defaul
                     output_txt2img_gallery,
                     [realesrgan_source, tabs],
                     _js=js_move_image('txt2img_gallery_output', 'img2img_editor'))
-
+            """
         gr.HTML("""
     <div id="90" style="max-width: 100%; font-size: 14px; text-align: center;" class="output-markdown gr-prose border-solid border border-gray-200 rounded gr-panel">
         <p>For help and advanced usage guides, visit the <a href="https://github.com/hlky/stable-diffusion-webui/wiki" target="_blank">Project Wiki</a></p>

--- a/webui.py
+++ b/webui.py
@@ -1754,6 +1754,12 @@ def imgproc(image,image_batch,imgproc_prompt,imgproc_toggles, imgproc_upscale_to
                     except:
                         pass
                     torch_gc()
+                    try:
+                        #if it's not loaded, this will fail, triggering the load
+                        if LDSR is None:
+                            LDSR = load_LDSR()
+                    except:
+                        LDSR = load_LDSR()
                     image = processLDSR(image)
                     outpathDir = os.path.join(outpath,'LDSR')
                     os.makedirs(outpathDir, exist_ok=True)
@@ -1773,6 +1779,12 @@ def imgproc(image,image_batch,imgproc_prompt,imgproc_toggles, imgproc_upscale_to
                     except:
                         pass
                     torch_gc()
+                    try:
+                        #if it's not loaded, this will fail, triggering the load
+                        if model is None:
+                            model = load_SD_model()
+                    except:
+                        model = load_SD_model()
                     image = processGoBig(image)
                     try:
                         del model
@@ -1780,6 +1792,12 @@ def imgproc(image,image_batch,imgproc_prompt,imgproc_toggles, imgproc_upscale_to
                     except:
                         pass
                     torch_gc()
+                    try:
+                        #if it's not loaded, this will fail, triggering the load
+                        if LDSR is None:
+                            LDSR = load_LDSR()
+                    except:
+                        LDSR = load_LDSR()
                     LDSR = load_LDSR()
                     image = processLDSR(image)
                     del LDSR

--- a/webui.py
+++ b/webui.py
@@ -1728,6 +1728,13 @@ def imgproc(image,image_batch,imgproc_prompt,imgproc_toggles, imgproc_upscale_to
                     except:
                         pass
                     torch_gc()
+                    #make sure model is loaded
+                    try:
+                        #if it's not loaded, this will fail, triggering the load
+                        if model is None:
+                            model = load_SD_model()
+                    except:
+                        model = load_SD_model()
                     image = processGoBig(image)
                     outpathDir = os.path.join(outpath,'GoBig')
                     os.makedirs(outpathDir, exist_ok=True)
@@ -1791,6 +1798,7 @@ def imgproc(image,image_batch,imgproc_prompt,imgproc_toggles, imgproc_upscale_to
     
     print("Done.")
     return output
+
 def run_GFPGAN(image, strength):
     image = image.convert("RGB")
 


### PR DESCRIPTION
Hi

UI:
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/87043616/187788890-dd258ceb-d3b4-428a-bb18-982ae1fafe93.png">


Here's a refactoring of the way the project handles upscaling, changes:

-Removal of Fix Faces and Upscale options from the generating interface (commented out currently in case we want to keep it)
-Addition of a new tab called Image Lab
-Addition of Single image and Batch processors 
-Cleaner Reimplementation of GoBig 
-Addition of Latent Diffusion Super Resolution upscaler
-Multiple processors in the same run
-Provides a location and base to add more processors like Animation generation or addition of future upscalers.

Future additions:
-Copy generation settings from generation interface to the goBig upscale settings for convenience (not big on JS, will take some time unless someone wants to tackle it)
-Batch process GoBig settings extractor from current file, using metadata or filename.
 
To use LDSR users will need to clone this custom repo https://github.com/devilismyfriend/latent-diffusion to ./src

LDSR was originally an example collab/cog project, I added a batch script to use it locally and also compiled into a module that can be loaded as model for this project.

After cloning users can use the download_model.bat to download and place the latest model files, locations follow previous established workflows and they should be placed under the ./src/latent-diffusion/experiments/pretrained_models.

Comparison of current upscalers:

Original 448x640
![image](https://user-images.githubusercontent.com/87043616/187347736-cc5ae769-1a74-4faa-8b6f-a35ccc62e646.png)


RealESRGAN, Fast, 4X, loss of details
![image](https://user-images.githubusercontent.com/87043616/187347816-a31ea87b-608e-461d-8976-5874fa0296d7.png)

GoBig, RealESRGAN 2X -> Sliced and SD diffused to add details, takes prompt/seed etc that will hopefully be pushable from the other tabs
![image](https://user-images.githubusercontent.com/87043616/187347860-62c0d9f0-4a9a-40fd-941d-0da7bc49ba03.png)


Latent Diffusion, Slow, 4X, doesn't alter the image like GoBig, produces some grain but is sharper and more accurate then RealESRGAN while providing better resolution then GoBig.
![image](https://user-images.githubusercontent.com/87043616/187347897-ec0bc99a-9cbf-4345-8b1d-8400faf90b88.png)

GoLatent, Slowest, 8X, combines the GoBig workflow with the Latent Diffusion upscaling method to add details and provide a clearer image through Latent Diffusion.
![image](https://i.imgur.com/sLvTLbI.jpg)