### PR TITLE
Load YAML settings into GUI

### DIFF
--- a/frontend/ui_functions.py
+++ b/frontend/ui_functions.py
@@ -1,10 +1,17 @@
 import re
+import sys
+import os
 import gradio as gr
 from PIL import Image, ImageFont, ImageDraw, ImageFilter, ImageOps
 from io import BytesIO
 import base64
 import re
+import yaml
 
+LOAD_SETTINGS_TXT2IMG_NAMES = [
+    "prompt", "ddim_steps", "sampler_name", "toggles", "realesrgan_model_name", "ddim_eta",
+    "n_iter", "batch_size", "cfg_scale", "seed", "height", "width", "fp", "variant_amount", "variant_seed"
+]
 
 def change_image_editor_mode(choice, cropped_image, resize_mode, width, height):
     if choice == "Mask":
@@ -120,3 +127,40 @@ def resize_image(resize_mode, im, width, height):
 def update_dimensions_info(width, height):
     pixel_count_formated = "{:,.0f}".format(width * height)
     return f"Aspect ratio: {round(width / height, 5)}\nTotal pixel count: {pixel_count_formated}"
+
+def load_settings(*values):
+    new_settings, key_names, checkboxgroup_info = values[-3:]
+    values = list(values[:-3])
+
+    if new_settings:
+        if type(new_settings) is str:
+            if os.path.exists(new_settings):
+                with open(new_settings, "r", encoding="utf8") as f:
+                    new_settings = yaml.safe_load(f)
+            elif new_settings.startswith("file://") and os.path.exists(new_settings[7:]):
+                with open(new_settings[7:], "r", encoding="utf8") as f:
+                    new_settings = yaml.safe_load(f)
+            else:
+                new_settings = yaml.safe_load(new_settings)
+        if type(new_settings) is not dict:
+            new_settings = {"prompt": new_settings}
+        if "txt2img" in new_settings:
+            new_settings = new_settings["txt2img"]
+        target = new_settings.pop("target", "txt2img")
+        if target != "txt2img":
+            print(f"Warning: applying settings to txt2img even though {target} is specified as target.", file=sys.stderr)
+
+        skipped_settings = {}
+        for key in new_settings.keys():
+            if key in key_names:
+                values[key_names.index(key)] = new_settings[key]
+            else:
+                skipped_settings[key] = new_settings[key]
+        if skipped_settings:
+            print(f"Settings could not be applied: {skipped_settings}", file=sys.stderr)
+
+    # Convert lists of checkbox indices to lists of checkbox labels:
+    for (cbg_index, cbg_choices) in checkboxgroup_info:
+        values[cbg_index] = [cbg_choices[i] for i in values[cbg_index]]
+
+    return values


### PR DESCRIPTION
I implemented YAML info files for samples.
Subsequently someone else implemented YAML config files.
However, currently there seems to be no way to load these when using the GUI.
The goal of this PR is to implement this feature.

Detailed goals:

1. Users can restore the default settings without restarting the program.
2. Users can open a file dialog to open a YAML file that specifies settings and load these into the program.
3. Optional: users can automatically read in settings from their OS's clipboard.
4. Optional: users can create more than one config file and switch between them.

I would like feedback regarding the following points:
1. How important do you judge goals 3 and 4 to be?
2. Goal 3 would require the addition of a third party package since Python does not seem to natively support reading in the OS's clipboard. Would this be okay? Alternatively there would be a textbox where users manually paste settings. **Edit: I just noticed that the recently merged PR did something with the clipboard. I'll look at how it's done there first.**
3. Where in the GUI should the option for loading settings be? So far I've only added an UI element for txt2img and put it between "Sampling method" and "Simple / Advanced" settings. Ideally the location would be the same for all tabs. Since there currently is another PR open a decision on this should perhaps be postponed until the other PR is finalized.

The specific design of the UI elements is not yet finalized and will depend on the implementation goals.
