### PR TITLE
Changed relauncher.py to have easier to set arguments for users, added --inbrowser as an argument choice

### DIFF
--- a/relauncher.py
+++ b/relauncher.py
@@ -8,7 +8,7 @@ import os, time
 extra_models_cpu = False
 
 # Automatically open a new browser window or tab on first launch
-inbrowser = False
+open_in_browser = False
 
 # Run Stable Diffusion in Optimized Mode - Only requires 4Gb of VRAM, but is significantly slower
 optimized = False
@@ -21,7 +21,7 @@ share = False
 
 
 # Enter other `--arguments` you wish to use - Must be entered as a `--argument ` syntax
-other_arguments = ""
+additional_arguments = ""
 
 
 
@@ -40,7 +40,7 @@ if optimized == True:
 if share == True:
     common_arguments += "--share "
 
-if inbrowser == True:
+if open_in_browser == True:
     inbrowser_argument = "--inbrowser "
 else:
     inbrowser_argument = ""
@@ -49,13 +49,16 @@ n = 0
 while True:
     if n == 0:
         print('Relauncher: Launching...')
-        os.system(f"python scripts/webui.py {common_arguments} {inbrowser_argument} {other_arguments}")
+        os.system(f"python scripts/webui.py {common_arguments} {inbrowser_argument} {additional_arguments}")
         
     else:
         print(f'\tRelaunch count: {n}')
         print('Relauncher: Launching...')
-        os.system(f"python scripts/webui.py {common_arguments} {other_arguments}")
+        os.system(f"python scripts/webui.py {common_arguments} {additional_arguments}")
     
-    print('Relauncher: Process is ending. Relaunching in 1s...')
     n += 1
+    if n > 100:
+        print ('Too many relaunch attempts. Aborting...')
+        break
+    print('Relauncher: Process is ending. Relaunching in 1s...')
     time.sleep(1)

--- a/relauncher.py
+++ b/relauncher.py
@@ -3,13 +3,24 @@ import os, time
 # USER CHANGABLE ARGUMENTS
 
 # Change to `True` if you wish to enable these common arguments
+
+# Run upscaling models on the CPU
 extra_models_cpu = False
+
+# Automatically open a new browser window or tab on first launch
 inbrowser = False
-optimized_turbo = False
+
+# Run Stable Diffusion in Optimized Mode - Only requires 4Gb of VRAM, but is significantly slower
 optimized = False
+
+# Run in Optimized Turbo Mode - Needs more VRAM than regular optimized mode, but is faster
+optimized_turbo = False
+
+# Creates a public xxxxx.gradio.app share link to allow others to use your interface (requires properly forwarded ports to work correctly)
 share = False
 
-# Enter other `--arguments` you wish to use
+
+# Enter other `--arguments` you wish to use - Must be entered as a `--argument ` syntax
 other_arguments = ""
 
 

--- a/relauncher.py
+++ b/relauncher.py
@@ -1,11 +1,50 @@
 import os, time
 
+# USER CHANGABLE ARGUMENTS
+
+# Change to `True` if you wish to enable these common arguments
+extra_models_cpu = False
+inbrowser = False
+optimized_turbo = False
+optimized = False
+share = False
+
+# Enter other `--arguments` you wish to use
+other_arguments = ""
+
+
+
+
+
+# BEGIN RELAUNCHER PYTHON CODE
+
+common_arguments = ""
+
+if extra_models_cpu == True:
+    common_arguments += "--extra-models-cpu "
+if optimized_turbo == True:
+    common_arguments += "--optimized-turbo "
+if optimized == True:
+    common_arguments += "--optimized "
+if share == True:
+    common_arguments += "--share "
+
+if inbrowser == True:
+    inbrowser_argument = "--inbrowser "
+else:
+    inbrowser_argument = ""
+
 n = 0
 while True:
-    print('Relauncher: Launching...')
-    if n > 0:
+    if n == 0:
+        print('Relauncher: Launching...')
+        os.system(f"python scripts/webui.py {common_arguments} {inbrowser_argument} {other_arguments}")
+        
+    else:
         print(f'\tRelaunch count: {n}')
-    os.system("python scripts/webui.py")
-    print('Relauncher: Process is ending. Relaunching in 0.5s...')
+        print('Relauncher: Launching...')
+        os.system(f"python scripts/webui.py {common_arguments} {other_arguments}")
+    
+    print('Relauncher: Process is ending. Relaunching in 1s...')
     n += 1
-    time.sleep(0.5)
+    time.sleep(1)

--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,7 @@ parser.add_argument("--gfpgan-dir", type=str, help="GFPGAN directory", default=(
 parser.add_argument("--gfpgan-gpu", type=int, help="run GFPGAN on specific gpu (overrides --gpu) ", default=0)
 parser.add_argument("--gpu", type=int, help="choose which GPU to use if you have multiple", default=0)
 parser.add_argument("--grid-format", type=str, help="png for lossless png files; jpg:quality for lossy jpeg; webp:quality for lossy webp, or webp:-compression for lossless webp", default="jpg:95")
+parser.add_argument("--inbrowser", action='store_true', help="automatically launch the interface in a new tab on the default browser", default=False)
 parser.add_argument("--ldsr-dir", type=str, help="LDSR directory", default=('./src/latent-diffusion' if os.path.exists('./src/latent-diffusion') else './LDSR'))
 parser.add_argument("--n_rows", type=int, default=-1, help="rows in the grid; use -1 for autodetect and 0 for n_rows to be same as batch_size (default: -1)",)
 parser.add_argument("--no-half", action='store_true', help="do not switch the model to 16-bit floats", default=False)
@@ -2039,10 +2040,11 @@ class ServerLauncher(threading.Thread):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         gradio_params = {
-            'show_error': True, 
+            'inbrowser': opt.inbrowser,
             'server_name': '0.0.0.0',
-            'server_port': opt.port, 
-            'share': opt.share
+            'server_port': opt.port,
+            'share': opt.share, 
+            'show_error': True
         }
         if not opt.share:
             demo.queue(concurrency_count=1)
@@ -2055,7 +2057,7 @@ class ServerLauncher(threading.Thread):
             try:
                 self.demo.launch(**gradio_params)
             except (OSError) as e:
-                print (f'Error: Port: {opt.port} is not open yet. Please wait...')
+                print (f'Error: Port: {opt.port} is not open yet. Please wait, this may take upwards of 60 seconds...')
                 time.sleep(10)
             else:
                 port_status = 0


### PR DESCRIPTION
Changed `relauncher.py` to have easier to set argument parameters for users to change. No longer is editing the main `os.system`  string needed. Now, users can choose to set some of the commonly used arguments (totally open to more additions here) to be True or False, with an added area for users to enter their own custom arguments as desired.

This really should make it easier for users to toggle what parameters they wish to launch with, and prevents them from needing to edit the main launch string for the `webui.py` file.

Addition changes to `relauncher.py` include increasing the relaunch time from 0.5 seconds to 1 second, to allow for easier program closing from the Terminal.

Changed `webui.py` to now include an  `--inbrowser` argument to open the interface automatically in a user's default browser. The default is set to `False`. Gradio params have also now been alphabetised. A notice was given to users waiting for port 7860 to open that it may take upwards of 60 seconds to become available.