### PR TITLE
Fix some things breaking when "Save individual images" is unticked

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -941,10 +941,10 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
                     save_sample(image, sample_path_i, filename, jpg_sample, prompts, seeds, width, height, steps, cfg_scale, 
 normalize_prompt_weights, use_GFPGAN, write_info_files, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
 skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode, False)
-                    if add_original_image or not simple_templating:
-                        output_images.append(image)
-                        if simple_templating:
-                            grid_captions.append( captions[i] )
+                if add_original_image or not simple_templating:
+                    output_images.append(image)
+                    if simple_templating:
+                        grid_captions.append( captions[i] )
 
             if opt.optimized:
                 mem = torch.cuda.memory_allocated()/1e6


### PR DESCRIPTION
Fixes #480 
For some reason, the code that adds an image to output_images—which goes back out to the web UI, and into the function that creates a grid if that's enabled—was conditionalized to _only_ run when `not skip_save`, i.e. when "Save individual images" is ticked.
Not sure if there was some reason for this at some point, or if someone just got the indentation level confused.