### PR TITLE
Enhanced support for variants

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -944,7 +944,10 @@ def process_images(
             for i, x_sample in enumerate(x_samples_ddim):
                 sanitized_prompt = prompts[i].replace(' ', '_').translate({ord(x): '' for x in invalid_filename_chars})
                 if variant_seed != None and variant_seed != '':
-                   seed_used = f"{current_seeds[i]}-{variant_seed}"
+                   if variant_amount == 0.0:
+                   	seed_used = f"{current_seeds[i]}-{variant_seed}"
+                   else:
+                        seed_used = f"{seed}-{variant_seed}"
                 else:
                    seed_used = f"{current_seeds[i]}"
                 if sort_samples:


### PR DESCRIPTION
I played a lot with variants and wanted to keep track of them by
extending the filename with the variant amount and variant seed.

While doing that, I found that currently, if you give a variant seed and
an image seed and generate more than one image, you end up with the
same image for all runs.

I used increasing variants with the same variant seed for creating
movies that show how a variant is increasingly deviating. I think
those are fascinating and added functionality to WebGUI.

If you now set a seed for the image and the variant and generate more
than one image, it will increase the variant amount by the initial
amount every step. So you can easily make a series of growing variants
and have them fully reproducible.

Here an example of the result:

![6s4jfw](https://user-images.githubusercontent.com/719156/188277713-165f76f2-0621-4d90-a93d-8e08e0b0cfef.gif)

![variants-example](https://user-images.githubusercontent.com/719156/188277603-2bbb9319-445a-4803-8373-cc0cc9e504a4.jpg)

I hope I made sense :)