### PR TITLE
Fix Slugify

### DIFF
--- a/webui_streamlit.py
+++ b/webui_streamlit.py
@@ -45,7 +45,7 @@ from ldm.modules.diffusionmodules.util import make_ddim_sampling_parameters, mak
      extract_into_tensor
 
 # we use slugify to make the filenames safe for windows and linux, its better than doing it manually
-# install it with 'pip install slugify'
+# install it with 'pip install python-slugify'
 from slugify import slugify
 
 try:


### PR DESCRIPTION
The prior recommended version of Slugify was Python 2 specific, python-slugify however is compatible with Python3 and uses the exact same calls and importation.

Also would be more ideal to simply create a requirements txt file, instead of comments I think.