### PR TITLE
modeldownload: Use webui_streamlit.yaml to update models

### DIFF
--- a/scripts/modeldownload.py
+++ b/scripts/modeldownload.py
@@ -14,41 +14,39 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 import os
-import os.path as op
+from omegaconf import OmegaConf
+import urllib.request
+import logging
 
-def updateModels():
-    if op.exists('models/ldm/stable-diffusion-v1/model.ckpt'):
-        pass
-    else:
-        os.system('wget https://www.googleapis.com/storage/v1/b/aai-blog-files/o/sd-v1-4.ckpt?alt=media -o models/ldm/stable-diffusion-v1/model.ckpt')
-        # os.rename('models/ldm/stable-diffusion-v1/sd-v1-4.ckpt?alt=media','models/ldm/stable-diffusion-v1/model.ckpt')
-        # os.system('wget https://cdn-lfs.huggingface.co/repos/ab/41/ab41ccb635cd5bd124c8eac1b5796b4f64049c9453c4e50d51819468ca69ceb8/14749efc0ae8ef0329391ad4436feb781b402f4fece4883c7ad8d10556d8a36a?response-content-disposition=attachment%3B%20filename%3D%22modelfull.ckpt%22 -o models/ldm/stable-diffusion-v1/model.ckpt')
-        # os.rename('models/ldm/stable-diffusion-v1/modelfull.ckpt','models/ldm/stable-diffusion-v1/model.ckpt')
-    
-    if op.exists('models/realesrgan/RealESRGAN_x4plus.pth') and op.exists('models/realesrgan/RealESRGAN_x4plus_anime_6B.pth'):
-        pass
-    else:
-        os.system('wget https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P models/realesrgan')
-        os.system('wget https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth -P models/realesrgan')
-    
-    if op.exists('models/gfpgan/GFPGANv1.3.pth'):
-        pass 
-    else:
-        os.system('wget https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth -P models/gfpgan')
-    
-    if op.exists('models/ldsr'):
-        pass
-    else:
-        os.system('git clone https://github.com/devilismyfriend/latent-diffusion.git')
-        os.system('mv latent-diffusion models/ldsr')
-    
-    if op.exists('models/ldsr/model.ckpt'):
-        pass
-    else:
-        os.mkdir('models/ldsr/experiments')
-        os.mkdir('models/ldsr')
-        os.system('wget https://heibox.uni-heidelberg.de/f/31a76b13ea27482981b4/?dl=1 -o models/ldsr/project.yaml')
-        # os.rename('models/ldsr/index.html?dl=1', 'models/ldsr/project.yaml')
-        os.system('wget https://heibox.uni-heidelberg.de/f/578df07c8fc04ffbadf3/?dl=1 -o models/ldsr/model.ckpt')
-        # os.rename('models/ldsr/index.html?dl=1', 'models/ldsr/model.ckpt')
-    
+logger = logging.getLogger(__name__)
+
+
+def download_file(download_link, folder, file_name):
+    model_path = os.path.join(folder, file_name)
+    if os.path.exists(model_path):
+        logger.info(file_name + " already exists")
+        return
+    os.makedirs(folder, exist_ok=True)
+    logger.info('Downloading ' + file_name + '...')
+    try:
+        urllib.request.urlretrieve(download_link, model_path)
+        logger.info("Downloaded " + file_name)
+    except:
+        logger.error("Failed to download " + file_name + " from " + download_link)
+        raise
+
+
+def update_models(models=None):
+    if models is None:
+        models = OmegaConf.load("configs/webui/webui_streamlit.yaml").model_manager.models
+
+    for model_name, model in models.items():
+        model_folder = model.save_location
+        logger.info("Preparing model: " + model_name)
+        for file_ in model.files.values():
+            download_file(file_.download_link, model_folder, file_.file_name)
+        logger.info("Model " + model_name + " is ready.")
+
+
+if __name__ == "__main__":
+    update_models()

--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -115,7 +115,9 @@ if (os.path.exists(".streamlit/config.toml")):
 if st.session_state["defaults"].daisi_app.running_on_daisi_io:
     if os.path.exists("scripts/modeldownload.py"):
         import modeldownload
-        modeldownload.updateModels()
+        modeldownload.update_models(
+            models=st.session_state["defaults"].model_manager.models,
+        )
 
 #
 #app = st.HydraApp(title='Stable Diffusion WebUI', favicon="", sidebar_state="expanded",


### PR DESCRIPTION
# Description

Please include:
- [X] relevant motivation
- [X] a summary of the change
- [ ] which issue is fixed.
- [X] any additional dependencies that are required for this change.

The `modeldownload.py` script is outdated (doesn't use the new paths), and there's a need for a script that downloads all models. It has been fixed to read the model_manager config in `streamlit_webui.yaml`, and download models to the correct locations.

# Checklist:

- [X] I have changed the base branch to `dev`
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation